### PR TITLE
Append to files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ members = [
 ]
 
 [replace]
-"waltz:0.2.0" = { path = "waltz" }
+"waltz:0.3.0" = { path = "waltz" }

--- a/waltz_cli/Cargo.toml
+++ b/waltz_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waltz_cli"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Pascal Hertleif <killercup@gmail.com>"]
 description = "Extract code blocks from Markdown and save them as files."
 readme = "../Readme.md"
@@ -13,7 +13,7 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 clap = "2.21.1"
-waltz = "0.2.1"
+waltz = "0.3.0"
 pulldown-cmark = "0.0.8"
 error-chain = "0.10.0"
 log = "0.3.6"
@@ -23,6 +23,7 @@ loggerv = "0.2.0"
 tempdir = "0.3"
 unindent = "0.1"
 assert_cli = "0.4"
+difference = "1.0"
 
 [badges]
 travis-ci = { repository = "killercup/waltz" }

--- a/waltz_cli/tests/concat.rs
+++ b/waltz_cli/tests/concat.rs
@@ -1,0 +1,74 @@
+#![allow(dead_code)]
+include!("utils/lib.rs");
+
+#[test]
+fn concat() {
+    given(r#"
+        # Getting started
+
+        First of all, create a simple `Cargo.toml` file:
+
+        ```toml,file=Cargo.toml
+        [package]
+        authors = ["Pascal Hertleif <killercup@gmail.com>"]
+        name = "foo"
+        version = "0.1.0"
+        ```
+
+        Now, let us define our first data structure by putting this into our
+        `src/lib.rs`:
+
+        ```rust,file=src/lib.rs
+        struct Foo {
+            x: i32,
+        }
+        ```
+
+        Very good. Let us implement a `new` function:
+
+        ```rust,file=src/lib.rs
+        impl Foo {
+            fn new(x: i32) -> Foo {
+                Foo { x: x }
+            }
+        }
+        ```
+
+        Great. How about a good default as well?
+
+        ```rust,file=src/lib.rs
+        use std::default::Default;
+
+        impl Default for Foo {
+            fn default() -> Foo {
+                Foo { x: 42 }
+            }
+        }
+        ```
+    "#)
+    .waltz()
+    .creates(file("Cargo.toml").containing(r#"
+        [package]
+        authors = ["Pascal Hertleif <killercup@gmail.com>"]
+        name = "foo"
+        version = "0.1.0"
+    "#))
+    .creates(file("src/lib.rs").containing(r#"
+        struct Foo {
+            x: i32,
+        }
+        impl Foo {
+            fn new(x: i32) -> Foo {
+                Foo { x: x }
+            }
+        }
+        use std::default::Default;
+
+        impl Default for Foo {
+            fn default() -> Foo {
+                Foo { x: 42 }
+            }
+        }
+    "#))
+    .cargo_check();
+}

--- a/waltz_cli/tests/simple.rs
+++ b/waltz_cli/tests/simple.rs
@@ -1,5 +1,5 @@
-#[cfg(test)]
-include!("_utils.rs");
+#![allow(dead_code)]
+include!("utils/lib.rs");
 
 #[test]
 fn simple() {


### PR DESCRIPTION
Multiple code blocks with the same path will now result in one file
being created at that path the contains ALL the code.

Fixes #5 
cc azerupi/mdBook#229