### PR TITLE
Add the packaging metadata to build the waltz snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: waltz
+version: master
+summary: Extract code files from Markdown
+description: |
+  Write guides in Markdown with code blocks that belong in several files, and
+  let waltz extract the code for you so you can build/run/test it easily.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  waltz:
+    command: waltz
+    plugs: [home]
+
+parts:
+  waltz:
+    source: .
+    plugin: rust
+    source-subdir: waltz_cli

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,3 +18,4 @@ parts:
     source: .
     plugin: rust
     source-subdir: waltz_cli
+    build-packages: [make]


### PR DESCRIPTION
This package will let you publish the latest warp in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.