### PR TITLE
Update version in README to new version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ Example:
 
 ### As Rust library
 
-Add `waltz = "0.2"` to your dependencies and use it!
+Add `waltz = "0.4"` to your dependencies and use it!
 
 **[API documentation](https://docs.rs/waltz/)**
 


### PR DESCRIPTION
Installing `0.2` leads to an incompatibility with pulldown_cmark